### PR TITLE
enhance Makefile to track .conf file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PAGES=$(patsubst %.txt,%.html,$(wildcard *.txt))
 
 .SUFFIXES: .txt .html
 
-.txt.html:
-	$(ASCIIDOC) $(ADOCOPTS) $*.txt
-	$(DOS2UNIX) $*.html
+%.html: %.txt freedoom-layout.conf
+	$(ASCIIDOC) $(ADOCOPTS) $<
+	$(DOS2UNIX) $@
 
 all: $(PAGES)


### PR DESCRIPTION
Adjust the Makefile so that the conf file is considered a dependency
of the output HTML files. Modifying the .conf file will mean "make"
will regenerate all HTML files.