### PR TITLE
Remove requests for all-new content

### DIFF
--- a/help.html
+++ b/help.html
@@ -59,18 +59,14 @@
 <div id="main">
 <div id="preamble">
 <div class="sectionbody">
-<div class="paragraph"><p>Freedoom is always looking for help.  This is a short list of some of
-the resources that the project is in need of.  If you can help out,
+<div class="paragraph"><p>Freedoom is always looking to improve.  This is a short list of some of
+the resources that the project may need.  If you can help out,
 please check the forum or Discord links in the sidebar to get in contact!</p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_musicians">Musicians</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><strong>In-level music</strong>: Freedoom needs music for its levels. Presently
-some of the music tracks are serving double duty for multiple levels.
-FreeDM, the deathmatch spinoff project, also needs some appropriate
-music for its levels.</p></div>
 <div class="paragraph"><p><strong>OPL synth instruments</strong>: If you like chiptunes, particularly for the
 Yamaha OPL2/OPL3 synth chips, then Freedoom needs instruments for its
 OPL MIDI instrument bank.  Check out the
@@ -81,12 +77,6 @@ to find out more.</p></div>
 <div class="sect1">
 <h2 id="_level_authors">Level authors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><strong>New levels</strong>: Freedoom is still in need of new single player levels
-in order to get a complete set of levels.  If you see a level that is
-just a square room with an exit switch, that is a currently unfilled
-slot.  If you are experienced making Doom levels and can spend the
-time to make a level for Freedoom, or maybe you have levels you&#8217;ve
-made and can donate to the project, please get in touch.</p></div>
 <div class="paragraph"><p><strong>Bugs</strong>: Sometimes bugs get reported in Freedoom&#8217;s levels.  Check out
 the <a href="https://github.com/freedoom/freedoom/labels/levels">bug list</a> to
 see what currently needs fixing.</p></div>
@@ -121,8 +111,8 @@ GitHub project</a>.</p></div>
 <div class="paragraph"><p>Freedoom does not accept financial donations nor bug bounties.  While
 such desires to support us this way are appreciated, we do not have a
 present need for financial assistance with development or hosting.</p></div>
-<div class="paragraph"><p>As an alternative, evangelize!  Spread the word of Freedoom and share
-your love for the game and encourage others to try it.</p></div>
+<div class="paragraph"><p>Spread the word instead! Share your love for Freedoom
+and encourage others to try it.</p></div>
 </div>
 </div>
 <p></p>

--- a/help.html
+++ b/help.html
@@ -65,16 +65,6 @@ please check the forum or Discord links in the sidebar to get in contact!</p></d
 </div>
 </div>
 <div class="sect1">
-<h2 id="_musicians">Musicians</h2>
-<div class="sectionbody">
-<div class="paragraph"><p><strong>OPL synth instruments</strong>: If you like chiptunes, particularly for the
-Yamaha OPL2/OPL3 synth chips, then Freedoom needs instruments for its
-OPL MIDI instrument bank.  Check out the
-<a href="https://github.com/freedoom/freedoom/tree/master/lumps/genmidi">documentation</a>
-to find out more.</p></div>
-</div>
-</div>
-<div class="sect1">
 <h2 id="_level_authors">Level authors</h2>
 <div class="sectionbody">
 <div class="paragraph"><p><strong>Bugs</strong>: Sometimes bugs get reported in Freedoom&#8217;s levels.  Check out

--- a/help.txt
+++ b/help.txt
@@ -1,16 +1,11 @@
 = Help Freedoom!
 // See COPYING.adoc for license terms of this file.
 
-Freedoom is always looking for help.  This is a short list of some of
-the resources that the project is in need of.  If you can help out,
+Freedoom is always looking to improve.  This is a short list of some of
+the resources that the project may need.  If you can help out,
 please check the forum or Discord links in the sidebar to get in contact!
 
 == Musicians
-
-**In-level music**: Freedoom needs music for its levels. Presently
-some of the music tracks are serving double duty for multiple levels.
-FreeDM, the deathmatch spinoff project, also needs some appropriate
-music for its levels.
 
 **OPL synth instruments**: If you like chiptunes, particularly for the
 Yamaha OPL2/OPL3 synth chips, then Freedoom needs instruments for its
@@ -19,13 +14,6 @@ https://github.com/freedoom/freedoom/tree/master/lumps/genmidi[documentation]
 to find out more.
 
 == Level authors
-
-**New levels**: Freedoom is still in need of new single player levels
-in order to get a complete set of levels.  If you see a level that is
-just a square room with an exit switch, that is a currently unfilled
-slot.  If you are experienced making Doom levels and can spend the
-time to make a level for Freedoom, or maybe you have levels you've
-made and can donate to the project, please get in touch.
 
 **Bugs**: Sometimes bugs get reported in Freedoom's levels.  Check out
 the https://github.com/freedoom/freedoom/labels/levels[bug list] to
@@ -56,5 +44,5 @@ Freedoom does not accept financial donations nor bug bounties.  While
 such desires to support us this way are appreciated, we do not have a
 present need for financial assistance with development or hosting.
 
-As an alternative, evangelize!  Spread the word of Freedoom and share
-your love for the game and encourage others to try it.
+Spread the word instead! Share your love for Freedoom
+and encourage others to try it.

--- a/help.txt
+++ b/help.txt
@@ -5,14 +5,6 @@ Freedoom is always looking to improve.  This is a short list of some of
 the resources that the project may need.  If you can help out,
 please check the forum or Discord links in the sidebar to get in contact!
 
-== Musicians
-
-**OPL synth instruments**: If you like chiptunes, particularly for the
-Yamaha OPL2/OPL3 synth chips, then Freedoom needs instruments for its
-OPL MIDI instrument bank.  Check out the
-https://github.com/freedoom/freedoom/tree/master/lumps/genmidi[documentation]
-to find out more.
-
 == Level authors
 
 **Bugs**: Sometimes bugs get reported in Freedoom's levels.  Check out


### PR DESCRIPTION
Now that every level has a unique track and there are no placeholders, the requests no longer make any sense.

I considered adding a request for sprites (mastermind) and sounds (a lot of stuff could use some polish), but given the irregular way FD updates it's best left up to the issues page and the community's own eyes and ears.

I've also gotten rid of that "evangelize" which kinda leaves a poor taste in some people's mouths.