### PR TITLE
Make body links more prominent

### DIFF
--- a/mint.css
+++ b/mint.css
@@ -28,7 +28,6 @@ body {
 }
 a {
   color: #226;
-  text-decoration: none;
   background: #efe;
 }
 a:active {
@@ -42,6 +41,7 @@ a:visited {
 }
 #navigation a {
   background: none;
+  text-decoration: none;
 }
 
 /* the header of the page will occupy the top 96 pixels and all of the


### PR DESCRIPTION
On the current website, links differ from the main text only by a barely-distinguishable shade of green in their background. On some monitors it's fine, on others I have to really look for it to even see the difference from the body text. This presents an accessibility issue and makes it especially trivial to miss links like the "APK" thing on this downloads page or even the "build of the latest version in Git".

I've restored the underline for links in the body text to make them less easy to miss. I haven't touched the stuff in the Contents sidebar as all of those are links and it's pretty obvious they are just by their positioning and designation, so underlines there just create visual noise.

![comparison](https://github.com/freedoom/freedoom.github.io/assets/462484/1d4b6015-84ab-45a2-8709-9c161a123ae4)
