### PR TITLE
manual: Make the manual more available

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,29 @@ modifications (&#8220;mods&#8221;) made for the original <em>Doom</em> games, ma
 </div>
 </div>
 <div class="sect1">
+<h2 id="_manual">Manual</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>Freedoom has a manual that has been translated into various languages:</p></div>
+<div class="ulist"><ul>
+<li>
+<p>
+<a href="freedoom-manual-en.pdf">Freedoom Manual In English</a>
+</p>
+</li>
+<li>
+<p>
+<a href="freedoom-manual-fr.pdf">Freedoom Manual In French</a>
+</p>
+</li>
+<li>
+<p>
+<a href="freedoom-manual-es.pdf">Freedoom Manual In Spanish</a>
+</p>
+</li>
+</ul></div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_project_news">Project News</h2>
 <div class="sectionbody">
 <div class="sect2">
@@ -110,7 +133,7 @@ The sailor monster type is formally banished from <em>Freedoom</em>’s own
 </ul></div>
 </div>
 <div class="sect3">
-<h4 id="_manual">Manual</h4>
+<h4 id="_manual_2">Manual</h4>
 <div class="ulist"><ul>
 <li>
 <p>

--- a/index.txt
+++ b/index.txt
@@ -13,6 +13,14 @@ _Doom_ fans and artists over the decades.
 
 For more information, see the link:about.html[What is Freedoom?] page.
 
+== Manual
+
+Freedoom has a manual that has been translated into various languages:
+
+  * link:freedoom-manual-en.pdf[Freedoom Manual In English]
+  * link:freedoom-manual-fr.pdf[Freedoom Manual In French]
+  * link:freedoom-manual-es.pdf[Freedoom Manual In Spanish]
+
 == Project News
 
 === link:#freedoom-0.12.1[2019-10-22: Freedoom 0.12.1 released][[freedoom-0.12.1]]


### PR DESCRIPTION
Add a "Manual" section to index.html which has links to the manuals.

----

With this change the start of the top level `index.html` looks like:
![manual-section](https://github.com/freedoom/freedoom.github.io/assets/2380178/5db51fcf-0ff2-4291-b0b3-acb64e77f723)

We can apply this at any time, but it would be nice to do so immediately after the release with the manuals at that time.

Either the companion PR in the main repo will have been applied, or the PDFs can be renamed in a way that this PR expects. 