### PR TITLE
Remove the "v" from the download links.

### DIFF
--- a/download.html
+++ b/download.html
@@ -67,7 +67,7 @@ the popular &#8220;deathmatch&#8221; game mode.</p></div>
 <div class="hdlist"><table>
 <tr>
 <td class="hdlist1">
-<a href="https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-v0.13.0.zip">Freedoom: Phase 1+2</a>
+<a href="https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-0.13.0.zip">Freedoom: Phase 1+2</a>
 <br>
 </td>
 <td class="hdlist2">
@@ -89,7 +89,7 @@ the popular &#8220;deathmatch&#8221; game mode.</p></div>
 </tr>
 <tr>
 <td class="hdlist1">
-<a href="https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedm-v0.13.0.zip">FreeDM</a>
+<a href="https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedm-0.13.0.zip">FreeDM</a>
 <br>
 </td>
 <td class="hdlist2">

--- a/download.txt
+++ b/download.txt
@@ -10,7 +10,7 @@ from id Software.  The second is a multiplayer-focused experience for
 the popular ``deathmatch'' game mode.
 
 [horizontal]
-https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-v0.13.0.zip[Freedoom: Phase 1+2]::
+https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-0.13.0.zip[Freedoom: Phase 1+2]::
 
     _Phase 1_ is the first part of the single-player game, containing
     four episodes which are nine levels each, smoothly paced for
@@ -25,7 +25,7 @@ https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedoom-v0.13.0.
     more skillful play than the previous episodes.  It is compatible
     with mods for _Doom II_.
 
-https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedm-v0.13.0.zip[FreeDM]::
+https://github.com/freedoom/freedoom/releases/download/v0.13.0/freedm-0.13.0.zip[FreeDM]::
 
     _FreeDM_ is a fast-paced competitive deathmatch game, part of the
     Freedoom project.  Rather than the usual single-player focused


### PR DESCRIPTION
There is a long tradition, and general convention, of naming assets with <package>-<version> without the "v" that "make dist" produces.

This reverts commit 785a840a5c9e644d47c6559c324152fde895859c.