### PR TITLE
add descriptions for projects and sort them

### DIFF
--- a/about.html
+++ b/about.html
@@ -115,9 +115,7 @@ project!</p></div>
 music tracks that can be reused royalty-free by <em>Doom</em> level authors
 and other independent game developers.</p></div>
 <div class="paragraph"><p><em>Freedoom</em> is liberally licensed under the
-<a href="https://en.wikipedia.org/wiki/BSD_licenses">BSD license</a> - all that is
-required is that you include a short copyright statement that credits
-the <em>Freedoom</em> project.</p></div>
+<a href="https://github.com/freedoom/freedoom/blob/master/COPYING.adoc">BSD license</a> - all you need is to include that same copyright statement and credit the <em>Freedoom</em> project.</p></div>
 <div class="paragraph"><p>For some examples of projects that have used <em>Freedoom</em>'s assets, take a look at the <a href="using.html">projects</a> page.</p></div>
 <div style="clear:both;"></div>
 </div>

--- a/about.txt
+++ b/about.txt
@@ -57,8 +57,8 @@ music tracks that can be reused royalty-free by _Doom_ level authors
 and other independent game developers.
 
 _Freedoom_ is liberally licensed under the
-https://en.wikipedia.org/wiki/BSD_licenses[BSD license] - all that is
-required is that you include a short copyright statement that credits
+https://github.com/freedoom/freedoom/blob/master/COPYING.adoc[BSD license]
+- all you need is to include that same copyright statement and credit
 the _Freedoom_ project.
 
 For some examples of projects that have used _Freedoom_'s assets, take a

--- a/using.html
+++ b/using.html
@@ -60,7 +60,8 @@
 <div class="sectionbody">
 <div class="paragraph"><p>Since <a href="about.html"><em>Freedoom</em> is free</a>, some other projects have
 used <em>Freedoom</em>'s assets.  We think this is a great use of the project
-and should be encouraged.  Here are an arbitrarily selected few that we know about.
+and should be encouraged. (Please be mindful of the <a href="https://github.com/freedoom/freedoom/blob/master/COPYING.adoc">license</a>, though.)</p></div>
+<div class="paragraph"><p>Here are an arbitrarily selected few that we know about.
 If you find any others, please let us know by filing an issue or pull
 request on the <a href="https://github.com/freedoom/freedoom.github.io">website
 project at GitHub</a>.</p></div>

--- a/using.html
+++ b/using.html
@@ -60,64 +60,66 @@
 <div class="sectionbody">
 <div class="paragraph"><p>Since <a href="about.html"><em>Freedoom</em> is free</a>, some other projects have
 used <em>Freedoom</em>'s assets.  We think this is a great use of the project
-and should be encouraged.  Here are the ones that we know about.  If
-you find any others, please let us know by filing an issue or pull
+and should be encouraged.  Here are an arbitrarily selected few that we know about.
+If you find any others, please let us know by filing an issue or pull
 request on the <a href="https://github.com/freedoom/freedoom.github.io">website
 project at GitHub</a>.</p></div>
+<h2>Applications</h2>
 <div class="ulist"><ul>
 <li>
 <p>
-<a href="https://zdoom.org/wiki/Barista">Barista</a>
+<a href="https://github.com/mkrupczak3/GZDoom-Android"><em>Freedoom</em> for Android</a> - a GZDoom Android port that comes pre-bundled with <em>Freedoom</em>.
+</p>
+</li>
+</ul></div>
+<h2>Standalone Games</h2>
+<div class="ulist"><ul>
+<li>
+<p>
+<a href="https://github.com/Blasphemer">Blasphemer</a> - a project to do for <em>Heretic</em> what <em>Freedoom</em> does for <em>Doom</em>.
 </p>
 </li>
 <li>
 <p>
-<a href="https://github.com/Blasphemer">Blasphemer</a>
+<a href="http://contest.gamedevfort.com/submission/657#.Ve8jwpcQlj0">Nocturne In Yellow</a> - a fantasy medieval first-person shooter where &#8220;you play as a dude marching through ancient castles with the realization that every myth and story ever made in the history of man is true and all of them are pissed off at you for having a pulse and four functional limbs.&#8221;
 </p>
 </li>
 <li>
 <p>
-<a href="http://www.indiedb.com/games/doominator-wave-survival">Doominator Wave Survival</a>
+<a href="https://filmsbykris.com/games/2021/cyber-griffin/website">Cyber Griffin</a> - a <em>Freedoom</em>-based sidescroller.
 </p>
 </li>
 <li>
 <p>
-<a href="https://filmsbykris.com/games/2021/cyber-griffin/website">Cyber Griffin</a>
+<a href="http://www.indiedb.com/games/terrorized">Terrorized</a> - a horror action RPG FPS.
 </p>
 </li>
 <li>
 <p>
-<a href="https://github.com/mkrupczak3/GZDoom-Android">Freedoom for Android</a>
+<a href="https://mr795.itch.io/lost-in-hell">Lost In Hell</a> - a game that combines elements from <em>Freedoom</em> and <a href="http://www.doomlegends.com/tpd/frames.html"><em>The People's Doom</em></a>.
 </p>
 </li>
 <li>
 <p>
-<a href="https://mobile.zame-dev.org/gloomy">Gloomy Dungeons</a>
+<a href="http://www.indiedb.com/games/doominator-wave-survival">Doominator Wave Survival</a> - a wave-based survival FPS.
 </p>
 </li>
 <li>
 <p>
-<a href="http://contest.gamedevfort.com/submission/657#.Ve8jwpcQlj0">Nocturne In Yellow</a>
+<a href="https://mobile.zame-dev.org/gloomy">Gloomy Dungeons</a> - a <em>very</em> retro-style FPS, think like pre-Doom, pre-Rise of the Triad.
+</p>
+</li>
+</ul></div>
+<h2>Mods</h2>
+<div class="ulist"><ul>
+<li>
+<p>
+<a href="https://zdoom.org/wiki/Barista">Barista</a> - a ZDoom mod &#8220;inspired by the <em>Doom</em> Bible, <em>Marathon</em> and <em>Half-Life</em>. It uses resources derived from <em>Freedoom</em> and various other sources, enough to replace everything needed by the single map and therefore work as a stand-alone.&#8221;
 </p>
 </li>
 <li>
 <p>
-<a href="https://www.reddit.com/r/gamedev/comments/xdwba/so_i_decided_to_make_an_fps_with_the_doom_engine/">Omega Point</a>
-</p>
-</li>
-<li>
-<p>
-<a href="http://www.indiedb.com/games/terrorized">Terrorized</a>
-</p>
-</li>
-<li>
-<p>
-<a href="http://www.moddb.com/mods/zombie-panic-doom">Zombie Panic</a>
-</p>
-</li>
-<li>
-<p>
-<a href="https://mr795.itch.io/lost-in-hell">Lost In Hell</a>
+<a href="https://codeberg.org/mc776/hideousdestructor">Hideous Destructor</a> - a GZDoom mod for both <em>Doom</em> and <em>Freedoom</em> that leans into the speculative fiction aspects of the monsters and weapons, with the side effect of turning the gameplay into a tactical simulation-style shooter with some parkour elements.
 </p>
 </li>
 </ul></div>

--- a/using.txt
+++ b/using.txt
@@ -2,20 +2,28 @@
 // See COPYING.adoc for license terms of this file.
 
 Since link:about.html[_Freedoom_ is free], some other projects have
-used _Freedoom_'s assets.  We think this is a great use of the project
-and should be encouraged.  Here are the ones that we know about.  If
-you find any others, please let us know by filing an issue or pull
-request on the https://github.com/freedoom/freedoom.github.io[website
+used _Freedoom_'s assets. We think this is a great use of the project
+and should be encouraged. Here are an arbitrarily selected few that we
+know about. If you find any others, please let us know by filing an
+issue or pull request on the https://github.com/freedoom/freedoom.github.io[website
 project at GitHub].
 
- * https://zdoom.org/wiki/Barista[Barista]
- * https://github.com/Blasphemer[Blasphemer]
- * http://www.indiedb.com/games/doominator-wave-survival[Doominator Wave Survival]
- * https://filmsbykris.com/games/2021/cyber-griffin/website[Cyber Griffin]
- * https://github.com/mkrupczak3/GZDoom-Android[Freedoom for Android]
- * https://mobile.zame-dev.org/gloomy[Gloomy Dungeons]
- * http://contest.gamedevfort.com/submission/657#.Ve8jwpcQlj0[Nocturne In Yellow]
- * https://www.reddit.com/r/gamedev/comments/xdwba/so_i_decided_to_make_an_fps_with_the_doom_engine/[Omega Point]
- * http://www.indiedb.com/games/terrorized[Terrorized]
- * http://www.moddb.com/mods/zombie-panic-doom[Zombie Panic]
- * https://mr795.itch.io/lost-in-hell[Lost In Hell]
+
+== Applications
+
+ * https://github.com/mkrupczak3/GZDoom-Android[Freedoom for Android] - a GZDoom Android port that comes pre-bundled with the singleplayer _Freedoom_ campaigns.
+
+== Standalone Games
+
+ * https://github.com/Blasphemer[Blasphemer] - a project to do for _Heretic_ what _Freedoom_ does for _Doom_.
+ * http://contest.gamedevfort.com/submission/657#.Ve8jwpcQlj0[Nocturne In Yellow] - a fantasy medieval first-person shooter where "you play as a dude marching through ancient castles with the realization that every myth and story ever made in the history of man is true and all of them are pissed off at you for having a pulse and four functional limbs."
+ * https://filmsbykris.com/games/2021/cyber-griffin/website[Cyber Griffin] - a _Freedoom_-based sidescroller.
+ * http://www.indiedb.com/games/terrorized[Terrorized] - a horror action RPG FPS.
+ * https://mr795.itch.io/lost-in-hell[Lost In Hell] - a game that combines elements from _Freedoom_ and http://www.doomlegends.com/tpd/frames.html[_The People's Doom_].
+ * http://www.indiedb.com/games/doominator-wave-survival[Doominator Wave Survival] - a wave-based survival FPS.
+ * https://mobile.zame-dev.org/gloomy[Gloomy Dungeons] - a _very_ retro-style FPS, think like pre-_Doom_, pre-_Rise of the Triad_.
+
+== Mods
+
+ * https://zdoom.org/wiki/Barista[Barista] - a ZDoom mod ``inspired by the _Doom_ Bible, _Marathon_ and _Half-Life_. It uses resources derived from _Freedoom_ and various other sources, enough to replace everything needed by the single map and therefore work as a stand-alone.''
+ * https://codeberg.org/mc776/hideousdestructor[Hideous Destructor] - a GZDoom mod for both _Doom_ and _Freedoom_ that leans into the speculative fiction aspects of the monsters and weapons, with the side effect of turning the gameplay into a tactical simulation-style shooter with some parkour elements.

--- a/using.txt
+++ b/using.txt
@@ -3,10 +3,11 @@
 
 Since link:about.html[_Freedoom_ is free], some other projects have
 used _Freedoom_'s assets. We think this is a great use of the project
-and should be encouraged. Here are an arbitrarily selected few that we
-know about. If you find any others, please let us know by filing an
-issue or pull request on the https://github.com/freedoom/freedoom.github.io[website
-project at GitHub].
+and should be encouraged. (Please be mindful of the https://github.com/freedoom/freedoom/blob/master/COPYING.adoc[license], though.)
+
+Here are an arbitrarily selected few that we know about. If you find any
+others, please let us know by filing an issue or pull request on the
+https://github.com/freedoom/freedoom.github.io[website project at GitHub].
 
 
 == Applications


### PR DESCRIPTION
Closes #53. Creators of these projects are **strongly** encouraged to post their own spiels to try to sell people on their work!

Omega Point seems to be not just dead but erased from the Internet so the PR will delete that entry.

A couple projects ("Doominator Wave Survival" and "Gloomy Dungeons 3D") are clearly marked on the linked pages as discontinued but what has been done still appears to be available so they stay.

At the risk of tooting my own horn, I'm taking the opportunity to add Hideous Destructor to the list.

I'm just going to remove Zombie Panic, though, sorry.