### PR TITLE
Reorganize links on left-hand column

### DIFF
--- a/404.html
+++ b/404.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/about.html
+++ b/about.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/download.html
+++ b/download.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/freedoom-layout.conf
+++ b/freedoom-layout.conf
@@ -52,13 +52,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/help.html
+++ b/help.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/index.html
+++ b/index.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/screenshots.html
+++ b/screenshots.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>

--- a/using.html
+++ b/using.html
@@ -40,13 +40,13 @@
       <li><a href="about.html">What is Freedoom?</a></li>
       <li><a href="screenshots.html">Screenshots</a></li>
       <li><a href="download.html">Download</a></li>
-      <li><a href="help.html">Help Freedoom!</a></li>
       <li><hr /></li>
+      <li><a href="using.html">Other Projects Using Freedoom Assets</a></li>
+      <li><hr /></li>
+      <li><a href="help.html">Contribute</a></li>
       <li><a href="https://github.com/freedoom/freedoom/issues">Report Issues</a></li>
       <li><a href="https://www.doomworld.com/forum/17-freedoom/">Discuss on the Forum</a></li>
       <li><a href="https://discord.gg/cGsSCXq">Talk on Discord</a></li>
-      <li><hr /></li>
-      <li><a href="using.html">Other Projects</a></li>
       <li style="text-align: center;">
         <a href="https://github.com/freedoom/freedoom"><img src="img/social/github.png" alt="GitHub" /></a>
         <a href="https://www.youtube.com/FreedoomGame"><img src="img/social/youtube.png" alt="YouTube" /></a>


### PR DESCRIPTION
Moving all feedback/submissions to the same place, changing the title to "Contribute" instead of a exclaimed imperative.

Other projects page link clarified to refer to other projects that use FD assets.

![_](https://github.com/freedoom/freedoom.github.io/assets/24984517/ec28d2b4-8c3d-4dca-8846-ecdb76c997f6)